### PR TITLE
Remember theme and toggle dark mode on page load/refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -470,6 +470,14 @@ LRisSqwatDjNDY5Cf7QNcKKjk89riq4VbX
     triggerThemeChange();
   }
 
+  // If set theme hasn't been changed by the user, check if the browser settings is set to prefer dark mode
+  // Will implicitly save dark mode to localStorage if the browser is set to dark mode, but I don't think that's a big problem.
+  if (!savedTheme) {
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      triggerThemeChange();
+    }
+  }
+
   themeToggle.addEventListener("click", triggerThemeChange);
 </script>
 

--- a/index.html
+++ b/index.html
@@ -447,18 +447,30 @@ LRisSqwatDjNDY5Cf7QNcKKjk89riq4VbX
   const body = document.body;
   const themeToggle = document.getElementById("theme-toggle");
   const themeIcon = document.getElementById("theme-icon");
+  const themeKey = "theme";
 
-  themeToggle.addEventListener("click", () => {
+  function triggerThemeChange()
+  {
     // Toggle the dark-mode class on the body
     body.classList.toggle("dark-mode");
 
     // Swap the icon text based on current theme
     if (body.classList.contains("dark-mode")) {
       themeIcon.textContent = "☀️"; // Sun icon
+      localStorage.setItem(themeKey, "dark");
     } else {
       themeIcon.textContent = "🌙"; // Moon icon
+      localStorage.setItem(themeKey, "light");
     }
-  });
+  }
+
+  const savedTheme = localStorage.getItem(themeKey);
+  if (savedTheme === "dark") {
+    // Default theme is light, so we toggle once to activate dark mode
+    triggerThemeChange();
+  }
+
+  themeToggle.addEventListener("click", triggerThemeChange);
 </script>
 
 </body>


### PR DESCRIPTION
- Extends the dark mode toggle to also save the 'selected' theme into localStorage
- If selected theme is set to be dark, it will activate it on each following page load until toggled back to light mode.
  - In the case where the user hasn't explicitly set a theme, it will do another check on the preferred color scheme set in the _browser settings_ and activate dark mode if needed.