### PR TITLE
Update speed.sh: Wrong location for IP 86.106.182.189

### DIFF
--- a/speed.sh
+++ b/speed.sh
@@ -1229,7 +1229,7 @@ init_routing_locations() {
         ROUTING_LOCATION_IPS+=("138.199.14.66")
         
         # Austria
-        ROUTING_LOCATION_NAMES+=("AT - Langenzersdorf: Hohl IT")
+        ROUTING_LOCATION_NAMES+=("AT - Vienna: Alwyzon")
         ROUTING_LOCATION_IPS+=("86.106.182.189")
         
         # Italy


### PR DESCRIPTION
Our Looking Glass (86.106.182.189/lg-vie-at.alwyzon.net) sits in Vienna (21st district of Vienna, Floridsdorf, to be specific).  Langenzersdorf on the other hand is a small municipality north of Vienna and I'm pretty sure there isn't even a single datacenter there.

Nice tool by the way!